### PR TITLE
enable `rhsmcertd.service`

### DIFF
--- a/podman-image-daily/Containerfile
+++ b/podman-image-daily/Containerfile
@@ -39,6 +39,8 @@ RUN rpm-ostree override replace --experimental --freeze \
     rm -fr /var/cache && \
     ostree container commit
 
+# Install subscription-manager and enable service to refresh certificates
 RUN rpm-ostree install subscription-manager && rm -fr /var/cache
+RUN systemctl enable rhsmcertd.service
 
 COPY  core /var/lib/systemd/linger/core


### PR DESCRIPTION
The service takes care of keeping the certificates of subscription-manager up to date.  Otherwise, the certs may expire.  I do not know why the service isn't enabled by default but the SMEs told me to do.